### PR TITLE
fix: Increase index when a drone is paused

### DIFF
--- a/P9-Backend/Services/DemoService.cs
+++ b/P9-Backend/Services/DemoService.cs
@@ -173,7 +173,10 @@ namespace P9_Backend.Services
                 {
                     //Skip if paused
                     if (drone.Paused)
+                    {
+                        i++;
                         continue;
+                    }
 
                     // Advance the drone by one step
                     AdvanceDrone(drone, i++);


### PR DESCRIPTION
Stops the indexing from going out of sync.